### PR TITLE
Maintenance/upgrade rusttype

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default = ["render"]
 render = ["miniquad"]
 
 [dependencies]
-rusttype = "0.7.7"
+rusttype = "0.9.1"
 miniquad = { version = "0.2.*", optional = true }
 
 [dev-dependencies]

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -34,7 +34,7 @@ fn main() {
             &mut ctx,
             &include_bytes!("font.ttf")[..],
             70,
-            quad_text::FontTexture::ascii_character_list(),
+            quad_text::FontAtlas::ascii_character_list(),
         )
         .unwrap();
         let text = quad_text::TextDisplay::new(&mut ctx, &system, Rc::new(font), "Hello world!");

--- a/examples/user_text.rs
+++ b/examples/user_text.rs
@@ -53,7 +53,7 @@ fn main() {
             &mut ctx,
             &include_bytes!("font.ttf")[..],
             70,
-            quad_text::FontTexture::cyrllic_character_list(),
+            quad_text::FontAtlas::cyrllic_character_list(),
         )
         .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,14 +211,6 @@ pub struct FontAtlas {
 pub enum Error {
     /// A glyph for this character is not present in font.
     NoGlyph(char),
-    /// An Error that comes directly from Rusttype.
-    RusttypeError(rusttype::Error),
-}
-
-impl From<rusttype::Error> for Error {
-    fn from(error: rusttype::Error) -> Self {
-        Error::RusttypeError(error)
-    }
 }
 
 // structure containing informations about a character of a font
@@ -313,8 +305,7 @@ impl FontAtlas {
         // building the freetype face object
         let font: Vec<u8> = font.bytes().map(|c| c.unwrap()).collect();
 
-        let collection = ::rusttype::FontCollection::from_bytes(&font[..])?;
-        let font = collection.into_font().unwrap();
+        let font = ::rusttype::Font::try_from_bytes(&font[..]).unwrap();
 
         // building the infos
         let (texture, chr_infos) = build_font_image(&font, characters_list.into_iter(), font_size)?;


### PR DESCRIPTION
Heya, this bumps `rusttype` to `0.9.1`, which notably now supports OTF fonts.

Noticed that `macroquad` builds `rusttype 0.7.9` and `0.8.3` and was wondering why -- turns out `rusttype 0.7.9` depends on `rusttype 0.8.3` ([really](https://gitlab.redox-os.org/redox-os/rusttype/-/blob/0.7.9/Cargo.toml#L30)).
